### PR TITLE
opbeans-loadgen compatibility

### DIFF
--- a/api.go
+++ b/api.go
@@ -23,6 +23,7 @@ func addAPIHandlers(r *gin.RouterGroup, db *sqlx.DB, logger *logrus.Logger) {
 	r.GET("/products/:id", h.getProductDetails)
 	r.GET("/products/:id/customers", h.getProductCustomers)
 	r.GET("/types", h.getProductTypes)
+	r.GET("/types/:id", h.getProductTypeDetails)
 	r.GET("/customers", h.getCustomers)
 	r.GET("/customers/:id", h.getCustomerDetails)
 	r.GET("/orders", h.getOrders)
@@ -157,6 +158,26 @@ func (h apiHandlers) getProductTypes(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, productTypes)
+}
+
+func (h apiHandlers) getProductTypeDetails(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		err := errors.Wrap(err, "failed to parse product type ID")
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	productType, err := getProductType(c.Request.Context(), h.db, id)
+	if err != nil {
+		err := errors.Wrap(err, "failed to get product type details")
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	if productType == nil {
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+	c.JSON(http.StatusOK, productType)
 }
 
 func (h apiHandlers) getCustomers(c *gin.Context) {

--- a/customers.go
+++ b/customers.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Customer struct {
-	ID          string `json:"id"`
+	ID          int    `json:"id"`
 	FullName    string `json:"full_name"`
 	CompanyName string `json:"company_name"`
 	Email       string `json:"email"`

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func Main(logger *logrus.Logger) error {
 	r.Static("/images", imagesDirPath)
 	r.StaticFile("/favicon.ico", faviconFilePath)
 	r.StaticFile("/", indexFilePath)
-	r.GET("/panic", handlePanic)
+	r.GET("/oopsie", handleOopsie)
 	r.GET("/rum-config.js", handleRUMConfig)
 
 	indexPrefixes := []string{"/dashboard", "/products", "/customers", "/orders"}
@@ -188,7 +188,7 @@ func newRouter(cacheStore persistence.CacheStore) *gin.Engine {
 	return r
 }
 
-func handlePanic(c *gin.Context) {
+func handleOopsie(c *gin.Context) {
 	switch c.Query("type") {
 	case "string":
 		panic("boom")


### PR DESCRIPTION
A few fixes to make opbeans-go more compatible with opbeans-loadgen:

- rename /panic to /oopsie, matching opbeans-python
- add support for 'POST /api/orders' and 'POST /api/orders/csv'
- add support for 'GET /api/types/:id'