### PR TITLE
Abort middleware after reverse proxying

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,6 +158,7 @@ func Main(logger *logrus.Logger) error {
 			u := backendURLs[rand.Intn(len(backendURLs))]
 			logger.Infof("proxying API request to %s", u)
 			httputil.NewSingleHostReverseProxy(u).ServeHTTP(c.Writer, c.Request)
+			c.Abort()
 			return
 		}
 		c.Next()


### PR DESCRIPTION
Without this, the local handlers still kick in, but the request is already cancelled and they raise an error.