### PR TITLE
Update log field names

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -45,3 +45,16 @@ func logrusMiddleware(c *gin.Context) {
 	entry.Time = start
 	entry.Info()
 }
+
+func newJSONFormatter() *logrus.JSONFormatter {
+	return &logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			// ECS
+			logrus.FieldKeyTime:  "@timestamp",
+			logrus.FieldKeyLevel: "log.level",
+			logrus.FieldKeyMsg:   "message",
+			// Non-ECS
+			logrus.FieldKeyFunc: "function.name",
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.Parse()
 	logrus.SetLevel(logLevel.Level)
 	if *logJSON {
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetFormatter(newJSONFormatter())
 	}
 	logrus.AddHook(&apmlogrus.Hook{})
 


### PR DESCRIPTION
Update the log field names to adhere to ECS:

- `msg` -> `message`
- `level` -> `log.level`
- `time` -> `@timestamp`

Also, rename `func` to `function.name`. Not strictly necessary, but a bit more in line with how we normally structure things.