### PR TITLE
fix: disabling cgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.11
 ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 COPY go.mod go.sum /src/opbeans-go/
 WORKDIR /src/opbeans-go
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM golang:1.11
+FROM golang:stretch
 ENV GO111MODULE=on
-ENV CGO_ENABLED=0
 COPY go.mod go.sum /src/opbeans-go/
 WORKDIR /src/opbeans-go
 RUN go mod download


### PR DESCRIPTION
There appears to be an incompatibility between
the glibc used by gcr.io/distroless/base and
golang:latest. We don't need cgo in integration
testing, since we use PostgreSQL and not SQLite.

see https://github.com/elastic/apm-integration-testing/commit/8be60f03e773d46dbfc7002d8fd4e6ac42f62c03