### PR TITLE
health depends on more robust in the docker-compose itself

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_started
-    healthcheck:
-      test: ["CMD", "/opbeans-go", "-healthcheck", "localhost:8000"]
-      retries: 10
-      interval: 10s
     command:
       - "/opbeans-go"
       - "-log-level=debug"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
         condition: service_healthy
       postgres:
         condition: service_started
+    healthcheck:
+      test: ["CMD", "/opbeans-go", "-healthcheck", "localhost:8000"]
+      retries: 10
+      interval: 10s
     command:
       - "/opbeans-go"
       - "-log-level=debug"
@@ -145,6 +149,12 @@ services:
       - pgdata:/var/lib/postgresql/data
     ports:
       - "127.0.0.1:5432:5432"
+
+  wait:
+    image: busybox
+    depends_on:
+      opbeans-go:
+        condition: service_healthy
 
 volumes:
   esdata:

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -4,7 +4,6 @@ load 'test_helper/bats-support/load'
 load 'test_helper/bats-assert/load'
 load test_helpers
 
-IMAGE="bats-opbeans"
 CONTAINER="opbeans-go"
 
 @test "build image" {
@@ -16,6 +15,11 @@ CONTAINER="opbeans-go"
 @test "create test container" {
 	run docker-compose up -d
 	assert_success
+}
+
+@test "test container with 0 as exitcode" {
+	run docker inspect -f {{.State.ExitCode}} $CONTAINER
+	assert_output '0'
 }
 
 @test "test container is running" {


### PR DESCRIPTION
Use case, when running `docker-compose up -d` the `opbeans-go` service is not validated by another service and therefore the `docker-compose up -d` finishes and the tests might happen when still the opbeans-go is warming up, so by adding a new `wait` service which depends on `opbeans-go` we will ensure teh execution of the tests will happen after the whole docker compose services are up and running and healthy.

## Highlights
- Docker-compose validates whether the opbeans-go is up and running.
- Add a test to validate the errorlevel of the docker container.