### PR TITLE
even a smaller docker image for the opbeans-go

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
+.ci
+.dockerignore
 .git
 .gitignore
+.gitmodules
+docker-compose*.yml
+Dockerfile
 Makefile
 README.md
-Dockerfile
 tests
 bats
+target


### PR DESCRIPTION
## Highlights
- Ignore unnecessary files to be copied.
- `100kb` smaller