### PR TITLE
fix: flag -u is not required when the env variable is passed from the pipeline

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -exo pipefail
 
 if [ $# -lt 1 ]; then
   echo "usage: ${0} Go_Agent_Version"
@@ -7,9 +7,14 @@ if [ $# -lt 1 ]; then
 fi
 AGENT_VERSION="${1}"
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+# Prepare the Go environment
+if [ -z ${GO_VERSION+x} ] ; then
+  echo "Using the already installed golang version."
+else
+  # Install Go using the same travis approach
+  echo "Installing ${GO_VERSION} with gimme."
+  eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+fi
 
 # Update agent dependencies
 go get "go.elastic.co/apm/...@${AGENT_VERSION}"


### PR DESCRIPTION
@axw found this issue

Although it's not ideal this fix.  I do see two different options:
- Add a second parameter to the script then the` apm-agent-go@tag:/Jenkinsfile` will be in charge to call it with two parameters
- Leave it as it is, the injection of the env variable should happen firstly in the shell context. In other words, we do not need to change anything in the ` apm-agent-go@tag:/Jenkinsfile`

I've decided the second one to simplify the call in the Jenkinsfile

## Tests

```
$ unset GO_VERSION 
$ ./bum-version.sh tag
Using the already installed golang version.
...

$ export GO_VERSION=1.12.1
$ ./bum-version.sh tag
Installing 1.12.1 with gimme.
go version go1.12.1 darwin/amd64
```