### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -21,7 +21,7 @@ go get "go.elastic.co/apm/...@${AGENT_VERSION}"
 go mod tidy
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add go.mod go.sum Dockerfile

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -20,6 +20,9 @@ fi
 go get "go.elastic.co/apm/...@${AGENT_VERSION}"
 go mod tidy
 
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+
 # Commit changes
-git add go.mod go.sum
+git add go.mod go.sum Dockerfile
 git commit -m "Bump version ${AGENT_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,13 @@ HEALTHCHECK \
   --interval=10s --retries=10 --timeout=3s \
   CMD ["/opbeans-go", "-healthcheck", "localhost:8000"]
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-go" \
+    org.label-schema.version="v1.8.0" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-go" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-go" \
+    org.label-schema.license="MIT"
+
 CMD ["/opbeans-go", "-frontend=/opbeans-frontend", "-db=sqlite3:/opbeans.db"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.


### Tests

```bash
$ IMAGE=docker.elastic.co/observability-ci/opbeans-go:89dd72cee30e72188b968c483aa0cfd1e6c13251
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-go",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-go",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-go",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "v1.8.0"
}
```