### PR TITLE
[dependabot] enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  # Enable version updates for go
+  - package-ecosystem: "gomod"
+    # Look for the dependencies in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-go"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-go"


### PR DESCRIPTION
### What

Enable dependabot to monitor any of the dependencies and notify the apm-agent-go team


### Why

Bump versions when required and monitor the ones related to any security issues