### PR TITLE
action: use composite updatecli

### DIFF
--- a/.github/workflows/bump-opbeans-go.yml
+++ b/.github/workflows/bump-opbeans-go.yml
@@ -2,15 +2,15 @@
 ## Workflow to periodically check if there is an available newer APM agent version, e.g.
 ## "v1.2.3". If so, then update to it and tag this repo with that version, e.g.
 ## "v1.2.3".
-name: Bump opbeans go
+name: bump-opbeans-go
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 20 * * 6'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   bump:
@@ -25,13 +25,9 @@ jobs:
           cache: true
           cache-dependency-path: '**/go.sum'
 
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: updatecli apply --config ./.ci/bump-opbeans-go.yml
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-opbeans-go.yml

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -4,6 +4,7 @@ name: OpenTelemetry Export Trace
 on:
   workflow_run:
     workflows:
+      - bump-opbeans-go
       - test
       - test-reporter
       - release


### PR DESCRIPTION
### What

Use GitHub composite action

### Why

Reuse code and solve the existing issue with Workflows won't be enabled for PRs created on behalf of `GitHub actions [bot]`, see https://github.com/elastic/ecs-logging-java/pull/200


### Issues

Similar to https://github.com/elastic/ecs-logging-java/pull/201
Requires https://github.com/elastic/apm-pipeline-library/pull/2076
