### PR TITLE
chore: enable dependabot version updates of github-actions yaml files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "22:00"
     reviewers:
       - "elastic/apm-agent-go"
 
@@ -17,5 +19,21 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "22:00"
     reviewers:
       - "elastic/apm-agent-go"
+
+  # GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "elastic/observablt-ci"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What does this PR do?

* Update dependabot to run on [Sundays](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) and use [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).
* Add dependabot for github actions.

Unfortunately it's not possible to pass different directories yet, see https://github.com/dependabot/dependabot-core/issues/2178

## Why is it important?

Reduce the noise during the week and create one PR with all the changes per package ecosystem