### PR TITLE
fix: updatecli issues when using golang

### DIFF
--- a/.ci/bump-opbeans-go.yml
+++ b/.ci/bump-opbeans-go.yml
@@ -67,3 +67,4 @@ targets:
       command: bash .ci/go-install-elastic-apm-go.sh
       environments:
         - name: PATH
+        - name: HOME


### PR DESCRIPTION
Trying to fix:

```
ERROR: environment variable "GOPATH" not found, skipping
ERROR: environment variable "GOMODCACHE" not found, skipping
...

command stderr output was:
----
warning: GOPATH set to GOROOT () has no effect
go: module cache not found: neither GOMODCACHE nor GOPATH is set

----

ERROR: something went wrong in target "go.sum" : "Shell command exited on error."
```

See https://github.com/elastic/opbeans-go/actions/runs/6991121548/job/19021342416#step:4:234

