### PR TITLE
feat: add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
+    groups:
+      gin:
+        patterns:
+        - "github.com/gin-contrib/*"
+        - "github.com/gin-gonic/*"
+      go-agent:
+        patterns:
+        - "go.elastic.co/apm*"
     reviewers:
       - "elastic/apm-agent-go"
 


### PR DESCRIPTION
dependabot can get noisy without groups

Group together go agents modules to reduce number of PRs