### PR TITLE
Require Go 1.22+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:stretch
+FROM golang:1.22.10
 ENV GO111MODULE=on
 COPY go.mod go.sum /src/opbeans-go/
 WORKDIR /src/opbeans-go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opbeans-go
 
-go 1.20
+go 1.22
 
 require (
 	github.com/gin-contrib/cache v1.3.0


### PR DESCRIPTION
Go 1.20 has reached EOL quite some time ago.
https://go.dev/doc/devel/release#policy

And we need to drop support for it to be able to upgrade `golang.org/x/crypto`.
See https://github.com/elastic/opbeans-go/pull/181

I upgraded to 1.22, as 1.21 is EOL too.