### PR TITLE
Drop support for go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opbeans-go
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/gin-contrib/cache v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/opbeans-go
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/gin-contrib/cache v1.3.1


### PR DESCRIPTION
Go 1.22 has reached EOL. Drop its support so we can upgrade dependencies that already did too.