### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner
+* @elastic/apm-agent-go
+
+# Sub-directories/files ownership
+/.github @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
       go-agent:
         patterns:
         - "go.elastic.co/apm*"
-    reviewers:
-      - "elastic/apm-agent-go"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -29,8 +27,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/apm-agent-go"
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.

Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with GitHub code owners.
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Relates: https://github.com/elastic/opbeans-go/issues/220